### PR TITLE
Replace PDF manual links with Shop Admin wiki guide

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.biano.cz"
 documentation: "https://eshop.biano.cz/wiki/biano-pixel-gtm"
 versions:
+  - sha: 1114d47f800f1d4fb56451036a4a1676ee62e10b
+    changeNotes: Replace PDF manual links with Shop Admin wiki guide
   - sha: 95f88f9840e466d04e4fbed27e0570d4007e6605
     changeNotes: Move biano.com/br to biano.com/br
   - sha: 4fe7cbc1858e97225b793e7f27ef40b9b4d70c08

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,5 @@
 homepage: "https://www.biano.cz"
-documentation: "https://pixel.biano.cz/pdf/GUIDE-PIXEL-GTM_CZ-EN.pdf"
+documentation: "https://eshop.biano.cz/wiki/biano-pixel-gtm"
 versions:
   - sha: 95f88f9840e466d04e4fbed27e0570d4007e6605
     changeNotes: Move biano.com/br to biano.com/br

--- a/template.tpl
+++ b/template.tpl
@@ -133,7 +133,7 @@ ___TEMPLATE_PARAMETERS___
     "type": "LABEL"
   },
   {
-    "help": "https://pixel.biano.cz/pdf/GUIDE-PIXEL-GTM_CZ-EN.pdf",
+    "help": "https://eshop.biano.cz/wiki/biano-pixel-gtm",
     "enablingConditions": [
       {
         "paramName": "eventType",
@@ -167,7 +167,7 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
-    "help": "Fill required fields according to https://pixel.biano.cz/pdf/GUIDE-PIXEL-GTM_CZ-EN.pdf",
+    "help": "Fill required fields according to https://eshop.biano.cz/wiki/biano-pixel-gtm",
     "enablingConditions": [
       {
         "paramName": "eventType",
@@ -230,7 +230,7 @@ ___TEMPLATE_PARAMETERS___
     ]
   },
   {
-    "help": "Fill required fields according to https://pixel.biano.cz/pdf/GUIDE-PIXEL-GTM_CZ-EN.pdf",
+    "help": "Fill required fields according to https://eshop.biano.cz/wiki/biano-pixel-gtm",
     "enablingConditions": [
       {
         "paramName": "eventType",
@@ -287,7 +287,7 @@ ___TEMPLATE_PARAMETERS___
         "canBeEmptyString": true
       },
       {
-        "displayName": "Alternatively you can push array of purchased items into Data Layer under key \"bianoPixel.orderItems\" as described in documentation: https://pixel.biano.cz/pdf/GUIDE-PIXEL-GTM_CZ-EN.pdf",
+        "displayName": "Alternatively you can push array of purchased items into Data Layer under key \"bianoPixel.orderItems\" as described in documentation: https://eshop.biano.cz/wiki/biano-pixel-gtm",
         "name": "purchase_dl_order_items",
         "type": "LABEL"
       },


### PR DESCRIPTION
The PDF manuals were retired in favor of the Shop Admin wiki (the old URLs now 301 there); this points the template help texts and gallery documentation link straight at https://eshop.biano.cz/wiki/biano-pixel-gtm (English available via the page's language switcher).

Includes the release entry pinned to 1114d47 — merge with a merge commit (not squash) so that sha lands on master, matching previous releases.